### PR TITLE
Badge url basic?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
+![Badge Label](badge-url)


### PR DESCRIPTION
Checking to see what this implicit url achieves for the markdown badge. 